### PR TITLE
Remove whitespace from start of code block

### DIFF
--- a/orbital-shortcodes.php
+++ b/orbital-shortcodes.php
@@ -11,6 +11,10 @@
 
 defined( 'ABSPATH' ) or die( 'Signal Error! Please try again.' );
 
+// Lower priority of auto paragraph insertion.
+remove_filter( 'the_content', 'wpautop' );
+add_filter( 'the_content', 'wpautop' , 12);
+
 class RadarThemesShortcodes
 {
 
@@ -287,7 +291,7 @@ class RadarThemesShortcodes
 
 		$syntax_output = '<pre>';
 		$syntax_output .= '<code class="hljs '. $atts['language'] .'">';
-		$syntax_output .= strip_tags(wp_specialchars_decode($content));
+		$syntax_output .= strip_tags(wp_specialchars_decode(ltrim($content)));
 		$syntax_output .= '</code>';
 		$syntax_output .= '</pre>';
 


### PR DESCRIPTION
This allows you to trigger the `[code]` shortcode like this:

```
[code language="coffee"]
expect(tokens[0]).toEqual value: '#', scopes: [docScope, singleLineComment, singleLineCommentOpen]
expect(tokens[1]).toEqual value: ' This is a comment.', scopes: [docScope, singleLineComment]
[/code]
```

without adding a blank line above the snippet.

Before:
![before](https://user-images.githubusercontent.com/12937335/41390584-7f238300-6f53-11e8-9027-bf993adae238.png)


After:
![after](https://user-images.githubusercontent.com/12937335/41390560-67e88ed8-6f53-11e8-9128-f18ad656f65a.png)
